### PR TITLE
Fixed Mongo parsing error

### DIFF
--- a/lib/mongoose-api-query.js
+++ b/lib/mongoose-api-query.js
@@ -4,7 +4,7 @@ module.exports = exports = function apiQueryPlugin (schema) {
     var model = this
       , params = model.apiQueryParams(rawParams);
     // Create the Mongoose Query object.
-    var query = model.find(params.searchParams).limit(params.per_page).skip((params.page - 1) * params.per_page)
+    var query = model.find(params.searchParams).limit(Number(params.per_page)).skip((params.page - 1) * params.per_page)
 
     if (params.sort) query = query.sort(params.sort)
 


### PR DESCRIPTION
Fixed Mongo parsing error "limit field must be numeric" by wrapping the per_page parameter with the JS Number() function.